### PR TITLE
Sprint1 #2: Multi-binding finalization

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -187,10 +187,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         metric_type = call.data["metric_type"]
         sensor_id = call.data["sensor_id"]
 
-        if any(
-            b.metric_type == metric_type and b.sensor_id == sensor_id
-            for b in run.bindings
-        ):
+        if run.has_binding(metric_type, sensor_id):
             raise ServiceValidationError(
                 f"Binding already exists for metric_type='{metric_type}' and sensor_id='{sensor_id}'."
             )

--- a/custom_components/plantrun/models.py
+++ b/custom_components/plantrun/models.py
@@ -86,6 +86,13 @@ class RunData:
     sensor_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     cultivar: CultivarSnapshot | None = None
 
+    def has_binding(self, metric_type: str, sensor_id: str) -> bool:
+        """Return True if the run already has the exact binding."""
+        return any(
+            binding.metric_type == metric_type and binding.sensor_id == sensor_id
+            for binding in self.bindings
+        )
+
     def to_dict(self) -> dict[str, Any]:
         # To avoid issues with nested dataclasses and asdict, we handle nested manually.
         data = asdict(self)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,6 +50,21 @@ class TestBindingCompatibility(unittest.TestCase):
         serialized = run.to_dict()
         self.assertEqual(serialized["bindings"][0]["id"], "bind_abc")
 
+    def test_has_binding_prevents_exact_duplicate_but_allows_same_metric(self) -> None:
+        run = RunData.from_dict(
+            {
+                "id": "run789",
+                "friendly_name": "Tent C",
+                "start_time": "2026-03-01T00:00:00",
+                "bindings": [
+                    {"metric_type": "temperature", "sensor_id": "sensor.t1"},
+                    {"metric_type": "temperature", "sensor_id": "sensor.t2"},
+                ],
+            }
+        )
+        self.assertTrue(run.has_binding("temperature", "sensor.t1"))
+        self.assertFalse(run.has_binding("temperature", "sensor.t3"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Finalizes multi-binding behavior by adding explicit exact-duplicate guard helper (`RunData.has_binding`) while preserving support for multiple entities per metric type.

## Acceptance Criteria Mapping
- [x] A run can have 2+ sensors for the same metric
- [x] Exact duplicates are prevented (same metric + entity)
- [x] Stable binding IDs preserved in serialization
- [x] Tests verify duplicate prevention and multi-binding support

## HA Best Practices
- Keeps stable entity unique_id semantics through persistent binding IDs
- Avoids registry collisions by preserving per-binding identity

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`

Closes #2
