### PR TITLE
Sprint1 #3: Dynamic entity lifecycle

### DIFF
--- a/custom_components/plantrun/sensor.py
+++ b/custom_components/plantrun/sensor.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
                 known_binding_ids.add(key)
                 entities.append(
                     PlantRunProxySensor(
+                        coordinator=coordinator,
                         run_id=run.id,
                         run_name=run.friendly_name,
                         binding=binding,
@@ -162,13 +163,21 @@ class PlantRunCultivarSensor(PlantRunBaseRunSensor):
         return run.cultivar.name
 
 
-class PlantRunProxySensor(SensorEntity):
+class PlantRunProxySensor(CoordinatorEntity[PlantRunCoordinator], SensorEntity):
     """Sensor that mirrors an existing HA entity but attaches to the PlantRun device."""
+
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(self, run_id: str, run_name: str, binding: Binding) -> None:
+    def __init__(
+        self,
+        coordinator: PlantRunCoordinator,
+        run_id: str,
+        run_name: str,
+        binding: Binding,
+    ) -> None:
         """Initialize the proxy sensor."""
+        super().__init__(coordinator)
         self.run_id = run_id
         self.run_name = run_name
         self.metric_type = binding.metric_type
@@ -184,6 +193,23 @@ class PlantRunProxySensor(SensorEntity):
             "name": self.run_name,
             "manufacturer": "PlantRun",
         }
+
+    def _binding_still_exists(self) -> bool:
+        """Return True while this binding still exists on the run."""
+        for run in self.coordinator.data:
+            if run.id != self.run_id:
+                continue
+            return any(binding.id == self.binding_id for binding in run.bindings)
+        return False
+
+    @property
+    def available(self) -> bool:
+        """Mark proxy unavailable when binding was removed at runtime."""
+        return self._binding_still_exists()
+
+    def _handle_coordinator_update(self) -> None:
+        """Update availability as runtime bindings are added/removed."""
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/tests/test_sensor_bindings.py
+++ b/tests/test_sensor_bindings.py
@@ -231,6 +231,37 @@ class TestDynamicBindingEntities(unittest.TestCase):
         self.assertEqual(len(new_proxy_ids), 1)
         self.assertNotEqual(new_proxy_ids[0], "plantrun_temperature_runA")
 
+    def test_removed_binding_marks_existing_proxy_unavailable(self) -> None:
+        const = sys.modules["custom_components.plantrun.const"]
+
+        run = RunData.from_dict(
+            {
+                "id": "runA",
+                "friendly_name": "Tent A",
+                "start_time": "2026-03-01T00:00:00",
+                "bindings": [{"metric_type": "temperature", "sensor_id": "sensor.t1"}],
+            }
+        )
+        coordinator = FakeCoordinator([run])
+        entry = FakeEntry("entry-1")
+        hass = FakeHass(const.DOMAIN, entry.entry_id, coordinator)
+        added_batches = []
+
+        def _async_add_entities(entities):
+            added_batches.append(list(entities))
+
+        asyncio.run(SENSOR_MODULE.async_setup_entry(hass, entry, _async_add_entities))
+        proxy = next(
+            entity
+            for entity in added_batches[0]
+            if isinstance(entity, SENSOR_MODULE.PlantRunProxySensor)
+        )
+        self.assertTrue(proxy.available)
+
+        run.bindings = []
+        coordinator._listeners[0]()
+        self.assertFalse(proxy.available)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Improves runtime entity lifecycle by tracking binding existence through coordinator updates and marking removed proxy bindings unavailable without HA restart.

## Acceptance Criteria Mapping
- [x] Adding binding still creates runtime proxy entity immediately
- [x] Removing binding updates runtime behavior (proxy availability reflects removal)
- [x] No HA restart required for normal binding CRUD

## HA Best Practices
- Dynamic entity behavior updated via coordinator listeners
- Stable unique IDs retained while avoiding stale active entities

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`

Closes #3
