### PR TITLE
Sprint1 #5: Run targeting UX hardening

### DIFF
--- a/custom_components/plantrun/config_flow.py
+++ b/custom_components/plantrun/config_flow.py
@@ -65,8 +65,8 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
         """Return the storage instance attached to this config entry."""
         return self.hass.data[DOMAIN][self.plantrun_config_entry.entry_id]["storage"]
 
-    def _get_active_runs_dict(self):
-        """Get a dict of run_id -> friendly_name for active runs."""
+    def _get_runs_dict(self, *, include_ended: bool = True):
+        """Get a dict of run_id -> human-friendly run label."""
         runs = {}
         if not hasattr(self, "hass") or DOMAIN not in self.hass.data:
             return runs
@@ -74,8 +74,10 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
         if not storage:
             return runs
         for run in storage.runs:
-            if run.status == "active":
-                runs[run.id] = f"{run.friendly_name} ({run.id[-6:]})"
+            if not include_ended and run.status != "active":
+                continue
+            status_label = "active" if run.status == "active" else "ended"
+            runs[run.id] = f"{run.friendly_name} ({status_label}, {run.id[-6:]})"
         return runs
 
     async def async_step_init(
@@ -216,9 +218,9 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_manage_run(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Step 1 of Management: Select the run."""
-        runs = self._get_active_runs_dict()
+        runs = self._get_runs_dict(include_ended=True)
         if not runs:
-            return self.async_abort(reason="no_active_runs")
+            return self.async_abort(reason="no_runs")
 
         if user_input is not None:
             self._target_run_id = user_input["run_id"]

--- a/tests/test_run_resolution.py
+++ b/tests/test_run_resolution.py
@@ -1,0 +1,100 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANTRUN_DIR = ROOT / "custom_components" / "plantrun"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ha = types.ModuleType("homeassistant")
+sys.modules.setdefault("homeassistant", ha)
+core = types.ModuleType("homeassistant.core")
+class HomeAssistant: pass
+core.HomeAssistant = HomeAssistant
+sys.modules["homeassistant.core"] = core
+helpers = types.ModuleType("homeassistant.helpers")
+storage_mod = types.ModuleType("homeassistant.helpers.storage")
+class Store:
+    def __init__(self,*_a,**_k):
+        pass
+storage_mod.Store = Store
+sys.modules["homeassistant.helpers"] = helpers
+sys.modules["homeassistant.helpers.storage"] = storage_mod
+
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(ROOT / "custom_components")]
+sys.modules.setdefault("custom_components", custom_components)
+
+plantrun_pkg = types.ModuleType("custom_components.plantrun")
+plantrun_pkg.__path__ = [str(PLANTRUN_DIR)]
+sys.modules["custom_components.plantrun"] = plantrun_pkg
+
+CONST = _load_module("custom_components.plantrun.const", PLANTRUN_DIR / "const.py")
+MODELS = _load_module("custom_components.plantrun.models", PLANTRUN_DIR / "models.py")
+RUN_RESOLUTION = _load_module(
+    "custom_components.plantrun.run_resolution", PLANTRUN_DIR / "run_resolution.py"
+)
+
+RunData = MODELS.RunData
+
+
+class FakeStorage:
+    def __init__(self, runs, active_run_id=None):
+        self.runs = runs
+        self.active_run_id = active_run_id
+
+    def get_run(self, run_id):
+        return next((run for run in self.runs if run.id == run_id), None)
+
+
+class TestRunResolution(unittest.TestCase):
+    def test_strict_active_resolution_lists_runs(self) -> None:
+        run_a = RunData(id="a1", friendly_name="Tent A", start_time="2026-03-01", status="active")
+        run_b = RunData(id="b1", friendly_name="Tent B", start_time="2026-03-01", status="active")
+        storage = FakeStorage([run_a, run_b])
+
+        with self.assertRaises(ValueError) as err:
+            RUN_RESOLUTION.resolve_run_or_raise(
+                storage,
+                run_id=None,
+                run_name=None,
+                use_active_run=True,
+                strict_active_resolution=True,
+                active_run_strategy=CONST.ACTIVE_RUN_STRATEGY_LEGACY,
+            )
+
+        self.assertIn("Multiple runs are active", str(err.exception))
+        self.assertIn("Tent A (a1)", str(err.exception))
+
+    def test_active_run_id_strategy_requires_valid_target(self) -> None:
+        run_a = RunData(id="a1", friendly_name="Tent A", start_time="2026-03-01", status="active")
+        run_b = RunData(id="b1", friendly_name="Tent B", start_time="2026-03-01", status="active")
+        storage = FakeStorage([run_a, run_b], active_run_id="missing")
+
+        with self.assertRaises(ValueError) as err:
+            RUN_RESOLUTION.resolve_run_or_raise(
+                storage,
+                run_id=None,
+                run_name=None,
+                use_active_run=True,
+                strict_active_resolution=False,
+                active_run_strategy=CONST.ACTIVE_RUN_STRATEGY_ACTIVE_RUN_ID,
+            )
+
+        self.assertIn("requires a valid active_run_id", str(err.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Improves run targeting UX by exposing ended runs in options-flow run selectors and by extending tests for deterministic active-run resolution errors.

## Acceptance Criteria Mapping
- [x] Users can target runs without manual ID hunting (status-labeled selector rows)
- [x] Ended runs are visible in management selection where relevant
- [x] Active-run fallback errors are specific and actionable
- [x] Deterministic active-run strategy behavior covered by tests

## HA Best Practices
- Uses HA-native Options Flow UX with human-readable labels
- Keeps service targeting deterministic for multi-active scenarios

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`

Closes #5
