### PR TITLE
Sprint2 #6: Run history/backlog first-class view foundations

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -1,9 +1,15 @@
 """The PlantRun integration."""
+import base64
+import binascii
 import logging
+import re
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components import frontend, websocket_api
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
@@ -19,20 +25,55 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .store import PlantRunStorage
 from .coordinator import PlantRunCoordinator
 from .models import Binding, CultivarSnapshot, Note, Phase, RunData
-from .providers_seedfinder import async_search_cultivar
+from .providers_seedfinder import async_fetch_cultivar_image_url, async_search_cultivar
 from .run_resolution import resolve_run_or_raise
+from .store import PlantRunStorage
 
 _LOGGER = logging.getLogger(__name__)
+
+PANEL_URL_PATH = "plantrun-dashboard"
+PANEL_TITLE = "PlantRun"
+PANEL_ICON = "mdi:sprout"
+PANEL_JS_URL = "/plantrun_frontend/plantrun-panel.js"
+UPLOADS_SUBDIR = "plantrun_uploads"
+
+
+def _storage_for_hass(hass: HomeAssistant) -> PlantRunStorage | None:
+    """Return the first configured PlantRun storage instance."""
+    domain_data = hass.data.get(DOMAIN, {})
+    for entry_data in domain_data.values():
+        if isinstance(entry_data, dict) and "storage" in entry_data:
+            storage = entry_data["storage"]
+            if isinstance(storage, PlantRunStorage):
+                return storage
+    return None
+
+
+@websocket_api.websocket_command({"type": "plantrun/get_runs"})
+@websocket_api.async_response
+async def websocket_get_runs(hass: HomeAssistant, connection: Any, msg: dict[str, Any]) -> None:
+    """Return full PlantRun runtime state for the sidebar dashboard."""
+    storage = _storage_for_hass(hass)
+    if storage is None:
+        connection.send_error(msg["id"], "not_loaded", "PlantRun is not loaded")
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "runs": [run.to_dict() for run in storage.runs],
+            "active_run_id": storage.active_run_id,
+        },
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PlantRun from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Register the frontend static path
+    # Register frontend static path
     hass.http.register_static_path(
         "/plantrun_frontend",
         hass.config.path("custom_components/plantrun/www"),
@@ -50,24 +91,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "coordinator": coordinator,
     }
 
+    if not hass.data[DOMAIN].get("_panel_registered"):
+        frontend.async_register_built_in_panel(
+            hass,
+            "custom",
+            sidebar_title=PANEL_TITLE,
+            sidebar_icon=PANEL_ICON,
+            frontend_url_path=PANEL_URL_PATH,
+            config={
+                "_panel_custom": {
+                    "name": "plantrun-dashboard-panel",
+                    "embed_iframe": False,
+                    "trust_external": False,
+                    "js_url": PANEL_JS_URL,
+                }
+            },
+            require_admin=False,
+        )
+        hass.data[DOMAIN]["_panel_registered"] = True
+
+    if not hass.data[DOMAIN].get("_ws_registered"):
+        websocket_api.async_register_command(hass, websocket_get_runs)
+        hass.data[DOMAIN]["_ws_registered"] = True
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
-    async def handle_create_run(call: ServiceCall) -> None:
-        """Handle the create_run service."""
-        friendly_name = call.data.get("friendly_name", "Unnamed Run")
-        start_time = call.data.get("start_time", datetime.utcnow().isoformat())
-        planted_date = call.data.get("planted_date")
-
-        new_run = RunData(
-            friendly_name=friendly_name,
-            start_time=start_time,
-            planted_date=planted_date
-        )
-        await storage.async_add_run(new_run)
-        await storage.async_set_active_run_id(new_run.id)
-        await coordinator.async_request_refresh()
-        _LOGGER.info("Created new run: %s", new_run.id)
 
     def resolve_target_run(call: ServiceCall) -> RunData:
         """Resolve target run from explicit id/name or active run compatibility args."""
@@ -85,22 +133,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except ValueError as err:
             raise ServiceValidationError(f"Run resolution failed: {err}") from err
 
+    async def refresh_after_update() -> None:
+        await coordinator.async_request_refresh()
+
+    async def handle_create_run(call: ServiceCall) -> None:
+        """Handle the create_run service."""
+        friendly_name = call.data.get("friendly_name", "Unnamed Run")
+        start_time = call.data.get("start_time", datetime.utcnow().isoformat())
+        planted_date = call.data.get("planted_date")
+
+        new_run = RunData(
+            friendly_name=friendly_name,
+            start_time=start_time,
+            planted_date=planted_date,
+        )
+        await storage.async_add_run(new_run)
+        await storage.async_set_active_run_id(new_run.id)
+        await refresh_after_update()
+        _LOGGER.info("Created new run: %s", new_run.id)
+
     async def handle_add_phase(call: ServiceCall) -> None:
         """Handle the add_phase service."""
         run = resolve_target_run(call)
-
         phase_name = call.data["phase_name"]
-
         now = datetime.utcnow().isoformat()
 
-        # End current phase
         if run.phases:
             run.phases[-1].end_time = now
 
-        # Add new phase
         run.phases.append(Phase(name=phase_name, start_time=now))
-        
-        # Smart end-date tracking for Harvest
+
         if phase_name.lower() == "harvest":
             run.end_time = now
             run.status = "ended"
@@ -113,25 +175,52 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await storage.async_set_active_run_id(run.id)
 
         await storage.async_update_run(run)
-        await coordinator.async_request_refresh()
+        await refresh_after_update()
         _LOGGER.info("Added phase %s to run %s", phase_name, run.id)
 
     async def handle_add_note(call: ServiceCall) -> None:
         """Handle the add_note service."""
         run = resolve_target_run(call)
-
         text = call.data["text"]
-
         now = datetime.utcnow().isoformat()
         run.notes.append(Note(text=text, timestamp=now))
         await storage.async_update_run(run)
-        await coordinator.async_request_refresh()
+        await refresh_after_update()
         _LOGGER.info("Added note to run %s", run.id)
+
+    async def handle_update_note(call: ServiceCall) -> None:
+        """Handle the update_note service."""
+        run = resolve_target_run(call)
+        note_id = call.data["note_id"]
+        new_text = call.data["text"]
+
+        note = next((n for n in run.notes if n.id == note_id), None)
+        if note is None:
+            raise ServiceValidationError(f"Note '{note_id}' not found on run '{run.id}'.")
+
+        note.text = new_text
+        note.timestamp = datetime.utcnow().isoformat()
+        await storage.async_update_run(run)
+        await refresh_after_update()
+        _LOGGER.info("Updated note %s on run %s", note_id, run.id)
+
+    async def handle_delete_note(call: ServiceCall) -> None:
+        """Handle the delete_note service."""
+        run = resolve_target_run(call)
+        note_id = call.data["note_id"]
+
+        initial_count = len(run.notes)
+        run.notes = [n for n in run.notes if n.id != note_id]
+        if len(run.notes) == initial_count:
+            raise ServiceValidationError(f"Note '{note_id}' not found on run '{run.id}'.")
+
+        await storage.async_update_run(run)
+        await refresh_after_update()
+        _LOGGER.info("Deleted note %s from run %s", note_id, run.id)
 
     async def handle_end_run(call: ServiceCall) -> None:
         """Handle the end_run service."""
         run = resolve_target_run(call)
-
         end_time = call.data.get("end_time", datetime.utcnow().isoformat())
 
         run.end_time = end_time
@@ -143,7 +232,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if storage.active_run_id == run.id:
             replacement = next((r.id for r in storage.runs if r.status == "active"), None)
             await storage.async_set_active_run_id(replacement)
-        await coordinator.async_request_refresh()
+        await refresh_after_update()
         _LOGGER.info("Ended run %s", run.id)
 
     async def handle_set_cultivar(call: ServiceCall) -> None:
@@ -156,9 +245,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         breeder = str(call.data.get("breeder", "")).strip()
         strain = str(call.data.get("strain", "")).strip()
 
-        # Compatibility behavior:
-        # - explicit breeder(+optional strain) => provider lookup
-        # - cultivar_name-only => manual snapshot (no provider call)
         if breeder:
             lookup_strain = strain or cultivar_name
             results = await async_search_cultivar(breeder, lookup_strain)
@@ -167,7 +253,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "Cultivar lookup failed: no SeedFinder result for "
                     f"breeder='{breeder}', strain='{lookup_strain}'."
                 )
-            run.cultivar = results[0]
+            selected = results[0]
+            if selected.detail_url and not selected.image_url:
+                selected.image_url = await async_fetch_cultivar_image_url(selected.detail_url)
+            run.cultivar = selected
+            if selected.image_url and not run.image_url:
+                run.image_url = selected.image_url
+                run.image_source = "seedfinder"
             _LOGGER.info(
                 "Attached Cultivar %s from SeedFinder to run %s", run.cultivar.name, run.id
             )
@@ -176,14 +268,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.info(
                 "Saved manual cultivar snapshot for run %s (name=%s)", run.id, cultivar_name
             )
-            
+
         await storage.async_update_run(run)
-        await coordinator.async_request_refresh()
-        
+        await refresh_after_update()
+
     async def handle_add_binding(call: ServiceCall) -> None:
         """Handle the add_binding service."""
         run = resolve_target_run(call)
-
         metric_type = call.data["metric_type"]
         sensor_id = call.data["sensor_id"]
 
@@ -194,10 +285,86 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         binding = Binding(metric_type=metric_type, sensor_id=sensor_id)
         run.bindings.append(binding)
-        
+
         await storage.async_update_run(run)
-        await coordinator.async_request_refresh()
-        _LOGGER.info("Bound %s to %s for run %s (binding_id=%s)", sensor_id, metric_type, run.id, binding.id)
+        await refresh_after_update()
+        _LOGGER.info(
+            "Bound %s to %s for run %s (binding_id=%s)",
+            sensor_id,
+            metric_type,
+            run.id,
+            binding.id,
+        )
+
+    async def handle_update_run(call: ServiceCall) -> None:
+        """Handle partial run updates for sidebar CRUD flows."""
+        run = resolve_target_run(call)
+
+        for field in ("friendly_name", "planted_date", "notes_summary", "status"):
+            if field in call.data:
+                setattr(run, field, call.data[field])
+
+        if "dry_yield_grams" in call.data:
+            run.dry_yield_grams = float(call.data["dry_yield_grams"])
+
+        if "base_config" in call.data:
+            base_config = call.data["base_config"]
+            if not isinstance(base_config, dict):
+                raise ServiceValidationError("base_config must be an object/map.")
+            run.base_config = base_config
+
+        if "image_url" in call.data:
+            run.image_url = call.data["image_url"]
+        if "image_source" in call.data:
+            run.image_source = call.data["image_source"]
+
+        await storage.async_update_run(run)
+        await refresh_after_update()
+
+    async def handle_set_run_image(call: ServiceCall) -> None:
+        """Handle image upload URL assignment for a run."""
+        run = resolve_target_run(call)
+
+        image_url = call.data.get("image_url")
+        image_source = call.data.get("image_source", "manual")
+        image_data = call.data.get("image_data")
+        file_name = call.data.get("file_name", "upload.jpg")
+
+        if image_data:
+            payload = image_data
+            if payload.startswith("data:"):
+                _, _, payload = payload.partition(",")
+            try:
+                raw = base64.b64decode(payload, validate=True)
+            except (binascii.Error, ValueError) as err:
+                raise ServiceValidationError("image_data is not valid base64 data.") from err
+
+            if len(raw) > 8 * 1024 * 1024:
+                raise ServiceValidationError("Uploaded image exceeds 8MB limit.")
+
+            suffix = Path(file_name).suffix.lower()
+            if suffix not in {".jpg", ".jpeg", ".png", ".webp"}:
+                suffix = ".jpg"
+
+            sanitized = re.sub(r"[^a-zA-Z0-9_-]+", "_", run.id)
+            ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            output_name = f"{sanitized}_{ts}{suffix}"
+
+            output_dir = Path(hass.config.path("www", UPLOADS_SUBDIR))
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_path = output_dir / output_name
+            output_path.write_bytes(raw)
+
+            run.image_url = f"/local/{UPLOADS_SUBDIR}/{output_name}"
+            run.image_source = "uploaded"
+        elif image_url:
+            run.image_url = image_url
+            run.image_source = image_source
+        else:
+            raise ServiceValidationError("Provide either image_data or image_url.")
+
+        await storage.async_update_run(run)
+        await refresh_after_update()
 
     run_resolution_schema = {
         vol.Optional(ATTR_RUN_ID): str,
@@ -209,51 +376,134 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ),
     }
 
-    # Register services
-    hass.services.async_register(
-        DOMAIN, "create_run", handle_create_run, schema=vol.Schema({
-            vol.Required("friendly_name"): str,
-            vol.Optional("start_time"): str,
-            vol.Optional("planted_date"): str,
-        })
+    def register_service(name: str, handler: Any, schema: vol.Schema) -> None:
+        if hass.services.has_service(DOMAIN, name):
+            hass.services.async_remove(DOMAIN, name)
+        hass.services.async_register(DOMAIN, name, handler, schema=schema)
+
+    register_service(
+        "create_run",
+        handle_create_run,
+        vol.Schema(
+            {
+                vol.Required("friendly_name"): str,
+                vol.Optional("start_time"): str,
+                vol.Optional("planted_date"): str,
+            }
+        ),
     )
 
-    hass.services.async_register(
-        DOMAIN, "add_phase", handle_add_phase, schema=vol.Schema({
-            **run_resolution_schema,
-            vol.Required("phase_name"): str,
-        })
+    register_service(
+        "add_phase",
+        handle_add_phase,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Required("phase_name"): str,
+            }
+        ),
     )
 
-    hass.services.async_register(
-        DOMAIN, "add_note", handle_add_note, schema=vol.Schema({
-            **run_resolution_schema,
-            vol.Required("text"): str,
-        })
+    register_service(
+        "add_note",
+        handle_add_note,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Required("text"): str,
+            }
+        ),
     )
-    
-    hass.services.async_register(
-        DOMAIN, "end_run", handle_end_run, schema=vol.Schema({
-            **run_resolution_schema,
-            vol.Optional("end_time"): str,
-        })
+
+    register_service(
+        "update_note",
+        handle_update_note,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Required("note_id"): str,
+                vol.Required("text"): str,
+            }
+        ),
     )
-    
-    hass.services.async_register(
-        DOMAIN, "set_cultivar", handle_set_cultivar, schema=vol.Schema({
-            **run_resolution_schema,
-            vol.Required("cultivar_name"): str,
-            vol.Optional("breeder"): str,
-            vol.Optional("strain"): str,
-        })
+
+    register_service(
+        "delete_note",
+        handle_delete_note,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Required("note_id"): str,
+            }
+        ),
     )
-    
-    hass.services.async_register(
-        DOMAIN, "add_binding", handle_add_binding, schema=vol.Schema({
-            **run_resolution_schema,
-            vol.Required("metric_type"): str,
-            vol.Required("sensor_id"): str,
-        })
+
+    register_service(
+        "end_run",
+        handle_end_run,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Optional("end_time"): str,
+            }
+        ),
+    )
+
+    register_service(
+        "set_cultivar",
+        handle_set_cultivar,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Required("cultivar_name"): str,
+                vol.Optional("breeder"): str,
+                vol.Optional("strain"): str,
+            }
+        ),
+    )
+
+    register_service(
+        "add_binding",
+        handle_add_binding,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Required("metric_type"): str,
+                vol.Required("sensor_id"): str,
+            }
+        ),
+    )
+
+    register_service(
+        "update_run",
+        handle_update_run,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Optional("friendly_name"): str,
+                vol.Optional("planted_date"): str,
+                vol.Optional("notes_summary"): str,
+                vol.Optional("status"): str,
+                vol.Optional("dry_yield_grams"): vol.Coerce(float),
+                vol.Optional("base_config"): dict,
+                vol.Optional("image_url"): str,
+                vol.Optional("image_source"): str,
+            }
+        ),
+    )
+
+    register_service(
+        "set_run_image",
+        handle_set_run_image,
+        vol.Schema(
+            {
+                **run_resolution_schema,
+                vol.Optional("image_data"): str,
+                vol.Optional("file_name"): str,
+                vol.Optional("image_url"): str,
+                vol.Optional("image_source"): str,
+            }
+        ),
     )
 
     return True
@@ -264,8 +514,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        has_other_entries = any(
+            isinstance(value, dict) and "storage" in value
+            for value in hass.data.get(DOMAIN, {}).values()
+        )
+        if not has_other_entries and hass.data.get(DOMAIN, {}).get("_panel_registered"):
+            frontend.async_remove_panel(hass, PANEL_URL_PATH)
+            hass.data[DOMAIN]["_panel_registered"] = False
 
     return unload_ok
+
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry when options change."""

--- a/custom_components/plantrun/models.py
+++ b/custom_components/plantrun/models.py
@@ -64,6 +64,8 @@ class CultivarSnapshot:
     name: str | None = None
     breeder: str | None = None
     flower_window_days: int | None = None
+    image_url: str | None = None
+    detail_url: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -85,6 +87,11 @@ class RunData:
     bindings: list[Binding] = field(default_factory=list)
     sensor_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     cultivar: CultivarSnapshot | None = None
+    dry_yield_grams: float | None = None
+    notes_summary: str | None = None
+    base_config: dict[str, Any] = field(default_factory=dict)
+    image_url: str | None = None
+    image_source: str | None = None
 
     def has_binding(self, metric_type: str, sensor_id: str) -> bool:
         """Return True if the run already has the exact binding."""
@@ -135,4 +142,9 @@ class RunData:
             bindings=bindings,
             sensor_history=data.get("sensor_history", {}),
             cultivar=cultivar,
+            dry_yield_grams=data.get("dry_yield_grams"),
+            notes_summary=data.get("notes_summary"),
+            base_config=data.get("base_config", {}),
+            image_url=data.get("image_url"),
+            image_source=data.get("image_source"),
         )

--- a/custom_components/plantrun/providers_seedfinder.py
+++ b/custom_components/plantrun/providers_seedfinder.py
@@ -91,6 +91,9 @@ async def async_search_cultivar(breeder: str, strain: str) -> list[CultivarSnaps
             for _, cells, anchor in scored_rows[:5]:
                 match_name = anchor.get_text(strip=True)
                 match_breeder = cells[1].get_text(strip=True) if len(cells) > 1 else breeder
+                detail_url = anchor.get("href")
+                if detail_url and detail_url.startswith("/"):
+                    detail_url = f"https://seedfinder.eu{detail_url}"
                 
                 # We could fetch detail page here to get flower_time, but for the wizard 
                 # a snapshot with just name/breeder is enough for now to avoid 5 slow requests.
@@ -98,7 +101,8 @@ async def async_search_cultivar(breeder: str, strain: str) -> list[CultivarSnaps
                     CultivarSnapshot(
                         name=match_name,
                         breeder=match_breeder,
-                        flower_window_days=None
+                        flower_window_days=None,
+                        detail_url=detail_url,
                     )
                 )
 
@@ -106,3 +110,38 @@ async def async_search_cultivar(breeder: str, strain: str) -> list[CultivarSnaps
         _LOGGER.error("Error searching SeedFinder: %s", err)
         
     return results
+
+
+async def async_fetch_cultivar_image_url(detail_url: str) -> str | None:
+    """Fetch a cultivar image URL from a SeedFinder detail page when available."""
+    if not detail_url:
+        return None
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(detail_url, timeout=20) as response:
+                if response.status != 200:
+                    return None
+                html = await response.text()
+    except Exception as err:
+        _LOGGER.debug("Cultivar image fetch failed for %s: %s", detail_url, err)
+        return None
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    og_image = soup.find("meta", attrs={"property": "og:image"})
+    if og_image and og_image.get("content"):
+        return og_image["content"]
+
+    tw_image = soup.find("meta", attrs={"name": "twitter:image"})
+    if tw_image and tw_image.get("content"):
+        return tw_image["content"]
+
+    image = soup.select_one("img[src*='seedfinder'], img[src*='strain']")
+    if image and image.get("src"):
+        src = image["src"]
+        if src.startswith("http"):
+            return src
+        return f"https://seedfinder.eu{src}" if src.startswith("/") else None
+
+    return None

--- a/custom_components/plantrun/services.yaml
+++ b/custom_components/plantrun/services.yaml
@@ -280,3 +280,216 @@ add_binding:
       required: true
       selector:
         text:
+
+update_note:
+  name: Update Note
+  description: Update an existing run note.
+  fields:
+    run_id:
+      name: Run ID
+      required: false
+      selector:
+        text:
+    run_name:
+      name: Run Name
+      required: false
+      selector:
+        text:
+    use_active_run:
+      name: Use Active Run
+      required: false
+      default: false
+      selector:
+        boolean:
+    strict_active_resolution:
+      name: Strict Active Resolution
+      required: false
+      default: false
+      selector:
+        boolean:
+    active_run_strategy:
+      name: Active Run Strategy
+      required: false
+      default: legacy
+      selector:
+        select:
+          options:
+            - legacy
+            - active_run_id
+            - first_active
+    note_id:
+      name: Note ID
+      required: true
+      selector:
+        text:
+    text:
+      name: Updated Text
+      required: true
+      selector:
+        text:
+
+delete_note:
+  name: Delete Note
+  description: Delete an existing run note.
+  fields:
+    run_id:
+      name: Run ID
+      required: false
+      selector:
+        text:
+    run_name:
+      name: Run Name
+      required: false
+      selector:
+        text:
+    use_active_run:
+      name: Use Active Run
+      required: false
+      default: false
+      selector:
+        boolean:
+    strict_active_resolution:
+      name: Strict Active Resolution
+      required: false
+      default: false
+      selector:
+        boolean:
+    active_run_strategy:
+      name: Active Run Strategy
+      required: false
+      default: legacy
+      selector:
+        select:
+          options:
+            - legacy
+            - active_run_id
+            - first_active
+    note_id:
+      name: Note ID
+      required: true
+      selector:
+        text:
+
+update_run:
+  name: Update Run
+  description: Update run metadata fields for dashboard CRUD workflows.
+  fields:
+    run_id:
+      name: Run ID
+      required: false
+      selector:
+        text:
+    run_name:
+      name: Run Name
+      required: false
+      selector:
+        text:
+    use_active_run:
+      name: Use Active Run
+      required: false
+      default: false
+      selector:
+        boolean:
+    strict_active_resolution:
+      name: Strict Active Resolution
+      required: false
+      default: false
+      selector:
+        boolean:
+    active_run_strategy:
+      name: Active Run Strategy
+      required: false
+      default: legacy
+      selector:
+        select:
+          options:
+            - legacy
+            - active_run_id
+            - first_active
+    friendly_name:
+      name: Friendly Name
+      required: false
+      selector:
+        text:
+    planted_date:
+      name: Planted Date
+      required: false
+      selector:
+        text:
+    notes_summary:
+      name: Summary
+      required: false
+      selector:
+        text:
+    dry_yield_grams:
+      name: Dry Yield (g)
+      required: false
+      selector:
+        number:
+    image_url:
+      name: Image URL
+      required: false
+      selector:
+        text:
+    image_source:
+      name: Image Source
+      required: false
+      selector:
+        text:
+
+set_run_image:
+  name: Set Run Image
+  description: Set image URL or upload base64 image data for a run.
+  fields:
+    run_id:
+      name: Run ID
+      required: false
+      selector:
+        text:
+    run_name:
+      name: Run Name
+      required: false
+      selector:
+        text:
+    use_active_run:
+      name: Use Active Run
+      required: false
+      default: false
+      selector:
+        boolean:
+    strict_active_resolution:
+      name: Strict Active Resolution
+      required: false
+      default: false
+      selector:
+        boolean:
+    active_run_strategy:
+      name: Active Run Strategy
+      required: false
+      default: legacy
+      selector:
+        select:
+          options:
+            - legacy
+            - active_run_id
+            - first_active
+    image_data:
+      name: Image Data (Base64/Data URL)
+      required: false
+      selector:
+        text:
+    file_name:
+      name: Filename
+      required: false
+      selector:
+        text:
+    image_url:
+      name: Image URL
+      required: false
+      selector:
+        text:
+    image_source:
+      name: Source Label
+      required: false
+      selector:
+        text:


### PR DESCRIPTION
## Summary
Introduces dashboard runtime APIs and run CRUD services that expose active + completed runs in one API surface for history/backlog-first UX.

## Acceptance Criteria Mapping
- [x] Completed runs are available through runtime UI APIs (not Dev Tools only)
- [x] Run detail payload includes phases/notes/bindings/media data required for timeline/detail rendering
- [x] Missing sensor data paths handled gracefully in API payload

## HA Best Practices
- Uses websocket/runtime API for HA-native panel UX
- Keeps service layer explicit and validation-driven

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`

Closes #6
