### PR TITLE
Sprint2 #8: Hybrid retention (recorder + daily rollups)

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -28,6 +28,7 @@ from .const import (
 from .coordinator import PlantRunCoordinator
 from .models import Binding, CultivarSnapshot, Note, Phase, RunData
 from .providers_seedfinder import async_fetch_cultivar_image_url, async_search_cultivar
+from .retention import async_capture_daily_rollup, get_summary_with_rollup_fallback
 from .run_resolution import resolve_run_or_raise
 from .store import PlantRunStorage
 from .summary import build_run_summary
@@ -86,7 +87,7 @@ async def websocket_get_run_summary(
         connection.send_error(msg["id"], "not_found", f"Run '{msg['run_id']}' not found")
         return
 
-    connection.send_result(msg["id"], build_run_summary(run))
+    connection.send_result(msg["id"], get_summary_with_rollup_fallback(storage, run))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -156,6 +157,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def refresh_after_update() -> None:
         await coordinator.async_request_refresh()
+
+    async def handle_create_daily_rollup(call: ServiceCall) -> None:
+        """Capture one daily summary snapshot for a target run."""
+        run = resolve_target_run(call)
+        await async_capture_daily_rollup(storage, run)
+        await refresh_after_update()
 
     async def handle_create_run(call: ServiceCall) -> None:
         """Handle the create_run service."""
@@ -412,6 +419,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vol.Optional("planted_date"): str,
             }
         ),
+    )
+
+    register_service(
+        "create_daily_rollup",
+        handle_create_daily_rollup,
+        vol.Schema({**run_resolution_schema}),
     )
 
     register_service(

--- a/custom_components/plantrun/retention.py
+++ b/custom_components/plantrun/retention.py
@@ -1,0 +1,37 @@
+"""Hybrid retention helpers (recorder-first + daily snapshots fallback)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from .models import RunData
+from .store import PlantRunStorage
+from .summary import build_run_summary
+
+
+def snapshot_day(ts: datetime | None = None) -> str:
+    """Return UTC day key for rollups."""
+    return (ts or datetime.utcnow()).date().isoformat()
+
+
+async def async_capture_daily_rollup(storage: PlantRunStorage, run: RunData) -> dict[str, Any]:
+    """Capture and persist one daily rollup summary for a run."""
+    summary = build_run_summary(run)
+    day = snapshot_day()
+    await storage.async_set_daily_rollup(run.id, day, summary)
+    return summary
+
+
+def get_summary_with_rollup_fallback(storage: PlantRunStorage, run: RunData) -> dict[str, Any]:
+    """Get summary with fallback to latest stored rollup when live history is sparse."""
+    live = build_run_summary(run)
+    if live.get("energy_kwh") is not None:
+        return live
+
+    run_rollups = storage.daily_rollups.get(run.id, {})
+    if not run_rollups:
+        return live
+
+    latest_day = sorted(run_rollups.keys())[-1]
+    return run_rollups[latest_day]

--- a/custom_components/plantrun/store.py
+++ b/custom_components/plantrun/store.py
@@ -25,6 +25,7 @@ class PlantRunStorage:
             "schema_version": STORE_SCHEMA_VERSION,
             "runs": [],
             "active_run_id": None,
+            "daily_rollups": {},
         }
 
     @staticmethod
@@ -36,6 +37,7 @@ class PlantRunStorage:
         migrated = copy.deepcopy(payload)
         migrated.setdefault("runs", [])
         migrated.setdefault("active_run_id", None)
+        migrated.setdefault("daily_rollups", {})
 
         normalized_runs: list[dict[str, Any]] = []
         for run in migrated.get("runs", []):
@@ -59,6 +61,7 @@ class PlantRunStorage:
                     "schema_version": STORE_SCHEMA_VERSION,
                     "runs": [],
                     "active_run_id": None,
+                    "daily_rollups": {},
                 },
                 True,
             )
@@ -75,6 +78,7 @@ class PlantRunStorage:
         current.setdefault("schema_version", STORE_SCHEMA_VERSION)
         current.setdefault("runs", [])
         current.setdefault("active_run_id", None)
+        current.setdefault("daily_rollups", {})
 
         return current, current != original
 
@@ -131,6 +135,22 @@ class PlantRunStorage:
             if run.id == run_id:
                 return run
         return None
+
+    @property
+    def daily_rollups(self) -> dict[str, dict[str, Any]]:
+        """Return persisted daily rollup snapshots."""
+        rollups = self._data.get("daily_rollups")
+        if isinstance(rollups, dict):
+            return rollups
+        return {}
+
+    async def async_set_daily_rollup(self, run_id: str, day: str, summary: dict[str, Any]) -> None:
+        """Persist one run/day summary snapshot."""
+        all_rollups = self.daily_rollups
+        run_rollups = all_rollups.setdefault(run_id, {})
+        run_rollups[day] = summary
+        self._data["daily_rollups"] = all_rollups
+        await self.async_save()
 
     async def async_add_run(self, run: RunData) -> None:
         """Add a new run."""

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,63 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANTRUN_DIR = ROOT / "custom_components" / "plantrun"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+ha = types.ModuleType("homeassistant")
+sys.modules.setdefault("homeassistant", ha)
+core = types.ModuleType("homeassistant.core")
+core.HomeAssistant = object
+sys.modules["homeassistant.core"] = core
+helpers = types.ModuleType("homeassistant.helpers")
+storage_mod = types.ModuleType("homeassistant.helpers.storage")
+storage_mod.Store = object
+sys.modules["homeassistant.helpers"] = helpers
+sys.modules["homeassistant.helpers.storage"] = storage_mod
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(ROOT / "custom_components")]
+sys.modules.setdefault("custom_components", custom_components)
+plantrun_pkg = types.ModuleType("custom_components.plantrun")
+plantrun_pkg.__path__ = [str(PLANTRUN_DIR)]
+sys.modules["custom_components.plantrun"] = plantrun_pkg
+
+MODELS = _load_module("custom_components.plantrun.models", PLANTRUN_DIR / "models.py")
+_load_module("custom_components.plantrun.summary", PLANTRUN_DIR / "summary.py")
+RETENTION = _load_module("custom_components.plantrun.retention", PLANTRUN_DIR / "retention.py")
+RunData = MODELS.RunData
+
+
+class FakeStorage:
+    def __init__(self):
+        self._daily_rollups = {}
+
+    @property
+    def daily_rollups(self):
+        return self._daily_rollups
+
+
+class TestRetention(unittest.TestCase):
+    def test_rollup_fallback_used_when_live_data_missing(self):
+        storage = FakeStorage()
+        storage.daily_rollups["run1"] = {"2026-03-09": {"run_id": "run1", "energy_kwh": 4.0}}
+        run = RunData(id="run1", friendly_name="Tent", start_time="2026-03-01", sensor_history={})
+
+        summary = RETENTION.get_summary_with_rollup_fallback(storage, run)
+        self.assertEqual(summary["energy_kwh"], 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store_migration.py
+++ b/tests/test_store_migration.py
@@ -79,6 +79,7 @@ class TestStoreMigration(unittest.TestCase):
         payload = {
             "schema_version": 2,
             "active_run_id": None,
+            "daily_rollups": {},
             "runs": [
                 {
                     "id": "run1",


### PR DESCRIPTION
## Summary
Adds optional daily rollup snapshot persistence in PlantRun store and fallback summary retrieval when live recorder-derived data is sparse.

## Acceptance Criteria Mapping
- [x] Recorder-first model kept (`build_run_summary` remains primary)
- [x] Daily rollup snapshot storage added (`daily_rollups` schema + capture service)
- [x] Retrieval falls back to stored rollups for older/sparse periods
- [x] Schema extension is migration-safe (`daily_rollups` defaults in normalization)

## HA Best Practices
- Backward-compatible store evolution
- Graceful degradation instead of hard failures for old/partial data

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`

Closes #8
