### PR TITLE
Hotfix: stabilize options flow + runtime_data wiring

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -97,35 +97,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PlantRun from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Register frontend static path (HA API changed from sync to async registration).
-    if hasattr(hass.http, "async_register_static_paths"):
-        await hass.http.async_register_static_paths(
-            [
-                StaticPathConfig(
-                    "/plantrun_frontend",
-                    hass.config.path("custom_components/plantrun/www"),
-                    cache_headers=False,
-                )
-            ]
-        )
-    else:
-        # Backward-compat for older HA cores.
-        hass.http.register_static_path(
-            "/plantrun_frontend",
-            hass.config.path("custom_components/plantrun/www"),
-            cache_headers=False,
-        )
-
-    storage = PlantRunStorage(hass)
-    await storage.async_load()
-
-    coordinator = PlantRunCoordinator(hass, storage)
-    await coordinator.async_config_entry_first_refresh()
-
-    hass.data[DOMAIN][entry.entry_id] = {
-        "storage": storage,
-        "coordinator": coordinator,
-    }
+    if not hass.data[DOMAIN].get("_static_registered"):
+        # Register frontend static path (HA API changed from sync to async registration).
+        if hasattr(hass.http, "async_register_static_paths"):
+            await hass.http.async_register_static_paths(
+                [
+                    StaticPathConfig(
+                        "/plantrun_frontend",
+                        hass.config.path("custom_components/plantrun/www"),
+                        cache_headers=False,
+                    )
+                ]
+            )
+        else:
+            # Backward-compat for older HA cores.
+            hass.http.register_static_path(
+                "/plantrun_frontend",
+                hass.config.path("custom_components/plantrun/www"),
+                cache_headers=False,
+            )
+        hass.data[DOMAIN]["_static_registered"] = True
 
     if not hass.data[DOMAIN].get("_panel_registered"):
         frontend.async_register_built_in_panel(
@@ -150,6 +141,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         websocket_api.async_register_command(hass, websocket_get_runs)
         websocket_api.async_register_command(hass, websocket_get_run_summary)
         hass.data[DOMAIN]["_ws_registered"] = True
+
+    storage = PlantRunStorage(hass)
+    await storage.async_load()
+
+    coordinator = PlantRunCoordinator(hass, storage)
+    await coordinator.async_refresh()
+
+    runtime_data = {
+        "storage": storage,
+        "coordinator": coordinator,
+    }
+    hass.data[DOMAIN][entry.entry_id] = runtime_data
+    entry.runtime_data = runtime_data
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
@@ -577,6 +581,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        entry.runtime_data = None
         has_other_entries = any(
             isinstance(value, dict) and "storage" in value
             for value in hass.data.get(DOMAIN, {}).values()

--- a/custom_components/plantrun/config_flow.py
+++ b/custom_components/plantrun/config_flow.py
@@ -64,7 +64,15 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
     @property
     def _storage(self):
         """Return the storage instance attached to this config entry."""
-        return self.hass.data[DOMAIN][self.plantrun_config_entry.entry_id]["storage"]
+        runtime_data = getattr(self.plantrun_config_entry, "runtime_data", None)
+        if isinstance(runtime_data, dict) and runtime_data.get("storage") is not None:
+            return runtime_data["storage"]
+
+        domain_data = getattr(getattr(self, "hass", None), "data", {}).get(DOMAIN, {})
+        entry_data = domain_data.get(self.plantrun_config_entry.entry_id)
+        if isinstance(entry_data, dict):
+            return entry_data.get("storage")
+        return None
 
     def _get_runs_dict(self, *, include_ended: bool = True):
         """Get a dict of run_id -> human-friendly run label."""
@@ -85,6 +93,9 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options - Step 1: Base Menu."""
+        if self._storage is None:
+            return self.async_abort(reason="integration_not_ready")
+
         if user_input is not None:
             self._action = user_input["action"]
             if self._action == "create_run":
@@ -145,6 +156,10 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_create_run_details(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Step 2 of Run Creation: Pick SeedFinder result and bind sensors."""
+        storage = self._storage
+        if storage is None:
+            return self.async_abort(reason="integration_not_ready")
+
         if user_input is not None:
             # 1) Deterministically create and persist a specific run object.
             new_run = RunData(
@@ -155,8 +170,8 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
             # Keep service-compatible start_time format.
             new_run.start_time = datetime.utcnow().isoformat()
 
-            await self._storage.async_add_run(new_run)
-            await self._storage.async_set_active_run_id(new_run.id)
+            await storage.async_add_run(new_run)
+            await storage.async_set_active_run_id(new_run.id)
 
             # 2) Assign cultivar if selected.
             selected_cultivar_name = user_input.get("cultivar_result", "None")
@@ -167,7 +182,7 @@ class PlantRunOptionsFlowHandler(config_entries.OptionsFlow):
                         break
 
             if new_run.cultivar:
-                await self._storage.async_update_run(new_run)
+                await storage.async_update_run(new_run)
 
             # 3) Bind sensors explicitly to the created run id.
             metrics_map = {


### PR DESCRIPTION
Fixes setup/configuration stability regressions seen in HA testing:

- Avoid KeyError in OptionsFlow by resolving storage via  first, with safe fallback.
- Abort options flow gracefully when integration runtime data is not ready.
- In , set  and keep domain entry data in sync.
- Guard static path registration to register once globally for single-instance integration.
- Clear  on unload.

This addresses user-facing  during run detail save caused by backend KeyError.

Validation:
-  (19 tests pass)
