### PR TITLE
BUG-004: use thread-safe state scheduling in proxy sensor callback

### DIFF
--- a/BUG_INTAKE_2026-03-09.md
+++ b/BUG_INTAKE_2026-03-09.md
@@ -1,0 +1,58 @@
+# PlantRun Bug Intake (2026-03-09)
+
+Status: collecting (do not fix yet)
+
+## Format
+- ID
+- Time
+- Area
+- Steps
+- Expected
+- Actual
+- Evidence (screenshot/log)
+- Severity
+
+## Bugs
+
+### BUG-001
+- Time: 2026-03-09
+- Area: Integration setup / static path registration
+- Steps: Add/configure PlantRun on current HA core
+- Expected: Entry setup succeeds
+- Actual: `AttributeError: 'HomeAssistantHTTP' object has no attribute 'register_static_path'`
+- Evidence: user screenshot/log (msg 1827)
+- Severity: Critical
+- Notes: already hotfixed in PR #22 (merged)
+
+### BUG-002
+- Time: 2026-03-09
+- Area: Options Flow / "Configure Run Details" save step
+- Steps: Start new grow run, assign multiple sensors, click save/submit
+- Expected: Run is created and bindings persisted
+- Actual: Generic UI error: `Unknown error occurred`
+- Evidence: user screenshot (msg 1832) + traceback (msg 1834)
+- Severity: High
+- Root cause (from traceback): `KeyError` in `config_flow._storage` because `self.hass.data[DOMAIN][self.plantrun_config_entry.entry_id]` missing during options flow step.
+- Stack clue: `/config/custom_components/plantrun/config_flow.py` line 158 (`await self._storage.async_add_run(new_run)`) -> line 67 (`_storage` property)
+- Notes: reproducible; likely race/lifecycle mismatch when options flow accesses runtime storage via entry_id lookup.
+
+### BUG-003
+- Time: 2026-03-09
+- Area: Sidebar panel visibility / integration startup UX
+- Steps: Open PlantRun integration page after setup errors
+- Expected: PlantRun sidebar panel visible when integration is loaded and usable
+- Actual: Sidebar entry not visible; integration card shows setup warning and no entries
+- Evidence: user screenshot (msg 1836)
+- Severity: High (blocks practical feature testing)
+- Notes: likely secondary effect of setup failure and/or panel registration lifecycle conditions.
+
+### BUG-004
+- Time: 2026-03-09
+- Area: Sensor proxy state updates / thread safety
+- Steps: Run integration on newer HA core, wait for source sensor state updates
+- Expected: Proxy sensor updates without thread-safety violations
+- Actual: Repeated runtime errors: `Detected that custom integration 'plantrun' calls async_write_ha_state from a thread other than the event loop` at `sensor.py:252`
+- Evidence: user log upload (msg 1849)
+- Severity: High (runtime spam + potential instability)
+- Root cause: state-change callback path can execute off event loop context while calling `async_write_ha_state()` directly.
+- Fix status: ready for review in hotfix PR (callback path switched to `schedule_update_ha_state()` for thread-safe scheduling).

--- a/custom_components/plantrun/sensor.py
+++ b/custom_components/plantrun/sensor.py
@@ -249,7 +249,8 @@ class PlantRunProxySensor(CoordinatorEntity[PlantRunCoordinator], SensorEntity):
             if new_state:
                 self._attr_native_value = new_state.state
                 self._apply_source_metadata(new_state.attributes)
-                self.async_write_ha_state()
+                # Thread-safe from worker/event contexts on newer HA cores.
+                self.schedule_update_ha_state()
 
         # Listen to state changes from the real sensor
         self.async_on_remove(

--- a/tests/test_sensor_bindings.py
+++ b/tests/test_sensor_bindings.py
@@ -38,6 +38,9 @@ def _install_homeassistant_stubs() -> None:
         def async_write_ha_state(self) -> None:
             return None
 
+        def schedule_update_ha_state(self, _force_refresh: bool = False) -> None:
+            return None
+
     sensor_mod.SensorEntity = SensorEntity
     sys.modules["homeassistant.components"] = components
     sys.modules["homeassistant.components.sensor"] = sensor_mod
@@ -282,6 +285,66 @@ class TestDynamicBindingEntities(unittest.TestCase):
         self.assertEqual(proxy._attr_state_class, "total_increasing")
         self.assertEqual(proxy._attr_device_class, "energy")
         self.assertEqual(proxy._attr_native_unit_of_measurement, "Wh")
+
+
+class TestProxyStateChangeThreadSafety(unittest.TestCase):
+    def test_state_change_callback_uses_schedule_update(self) -> None:
+        run = RunData.from_dict(
+            {
+                "id": "runT",
+                "friendly_name": "Tent T",
+                "start_time": "2026-03-01T00:00:00",
+                "bindings": [{"metric_type": "temperature", "sensor_id": "sensor.t1"}],
+            }
+        )
+        coordinator = FakeCoordinator([run])
+        proxy = SENSOR_MODULE.PlantRunProxySensor(
+            coordinator=coordinator,
+            run_id="runT",
+            run_name="Tent T",
+            binding=run.bindings[0],
+        )
+
+        captured = {}
+
+        def _capture_track(_hass, _entity_ids, callback):
+            captured["callback"] = callback
+            return lambda: None
+
+        SENSOR_MODULE.async_track_state_change_event = _capture_track
+
+        class _States:
+            @staticmethod
+            def get(_entity_id):
+                return None
+
+        proxy.hass = types.SimpleNamespace(states=_States())
+
+        calls = {"scheduled": 0, "written": 0}
+
+        def _schedule_update_ha_state(_force_refresh: bool = False) -> None:
+            calls["scheduled"] += 1
+
+        def _async_write_ha_state() -> None:
+            calls["written"] += 1
+
+        proxy.schedule_update_ha_state = _schedule_update_ha_state
+        proxy.async_write_ha_state = _async_write_ha_state
+
+        asyncio.run(proxy.async_added_to_hass())
+
+        event = types.SimpleNamespace(
+            data={
+                "new_state": types.SimpleNamespace(
+                    state="21.4",
+                    attributes={"unit_of_measurement": "°C"},
+                )
+            }
+        )
+        captured["callback"](event)
+
+        self.assertEqual(calls["scheduled"], 1)
+        self.assertEqual(calls["written"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause
`PlantRunProxySensor` handled source sensor state-change events with a direct `async_write_ha_state()` call. On newer Home Assistant cores this callback path can run off the event loop thread, triggering runtime thread-safety errors.

## Fix
- Replace direct `async_write_ha_state()` in the state-change callback with `schedule_update_ha_state()`
- Keep initial in-loop state sync behavior unchanged
- Add a lightweight regression test asserting callback path schedules an update instead of direct async write
- Update `BUG_INTAKE_2026-03-09.md` BUG-004 fix status

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
  - Ran 22 tests: **OK**
