### PR TITLE
Hotfix: fix PlantRun sidebar blank screen (issue #25)

### DIFF
--- a/custom_components/plantrun/www/plantrun-panel.js
+++ b/custom_components/plantrun/www/plantrun-panel.js
@@ -1,4 +1,12 @@
-import { LitElement, html, css } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
+const HaPanelLovelace = customElements.get("ha-panel-lovelace");
+
+if (!HaPanelLovelace) {
+  throw new Error("PlantRun panel requires Home Assistant's frontend runtime.");
+}
+
+const LitElement = Object.getPrototypeOf(HaPanelLovelace);
+const html = LitElement.prototype.html;
+const css = LitElement.prototype.css;
 
 const PHASES = ["Seedling", "Vegetative", "Flowering", "Harvest"];
 

--- a/tests/test_stability_lifecycle.py
+++ b/tests/test_stability_lifecycle.py
@@ -304,6 +304,13 @@ class StabilityLifecycleTests(unittest.TestCase):
         self.assertIn("storage", entry.runtime_data)
         self.assertIn("coordinator", entry.runtime_data)
 
+    def test_panel_script_is_classic_script_compatible(self):
+        panel_script = (PLANTRUN_DIR / "www" / "plantrun-panel.js").read_text(encoding="utf-8")
+
+        self.assertNotIn('import {', panel_script)
+        self.assertIn('customElements.get("ha-panel-lovelace")', panel_script)
+        self.assertIn('"js_url": PANEL_JS_URL', (PLANTRUN_DIR / "__init__.py").read_text(encoding="utf-8"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Root cause
Home Assistant loads the PlantRun sidebar panel via `_panel_custom.js_url`, which is evaluated as a classic script. `custom_components/plantrun/www/plantrun-panel.js` started with a top-level ES module `import`, which caused:

`SyntaxError: Cannot use import statement outside a module`

That error prevented the panel from rendering and produced the blank screen.

## Fix summary
- Removed top-level module import from `plantrun-panel.js`
- Reused Home Assistant's already-loaded Lit runtime (`ha-panel-lovelace` prototype)
- Added regression test to enforce classic-script compatibility while panel is still registered through `js_url`

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- Result: `Ran 22 tests ... OK`

## Scope
- Hotfix-only for sidebar blank-screen bug (#25)
- No feature changes
