### PR TITLE
Hotfix: load PlantRun sidebar via module_url (fix blank screen)

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -1,6 +1,7 @@
 """The PlantRun integration."""
 import base64
 import binascii
+import json
 import logging
 import re
 from datetime import datetime
@@ -41,7 +42,10 @@ _LOGGER = logging.getLogger(__name__)
 PANEL_URL_PATH = "plantrun-dashboard"
 PANEL_TITLE = "PlantRun"
 PANEL_ICON = "mdi:sprout"
-PANEL_JS_URL = "/plantrun_frontend/plantrun-panel.js"
+_MANIFEST_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_text(encoding="utf-8"))[
+    "version"
+]
+PANEL_MODULE_URL = f"/plantrun_frontend/plantrun-panel.js?v={_MANIFEST_VERSION}"
 UPLOADS_SUBDIR = "plantrun_uploads"
 
 
@@ -130,7 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "name": "plantrun-dashboard-panel",
                     "embed_iframe": False,
                     "trust_external": False,
-                    "js_url": PANEL_JS_URL,
+                    "module_url": PANEL_MODULE_URL,
                 }
             },
             require_admin=False,

--- a/tests/test_stability_lifecycle.py
+++ b/tests/test_stability_lifecycle.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import sys
 import types
 import unittest
@@ -256,6 +257,9 @@ class StabilityLifecycleTests(unittest.TestCase):
         self.assertEqual(result["reason"], "integration_not_ready")
 
     def test_setup_entry_sets_runtime_data_and_registers_static_once(self):
+        frontend = sys.modules["homeassistant.components.frontend"]
+        frontend._registered.clear()
+
         class FakeHTTP:
             def __init__(self):
                 self.calls = 0
@@ -301,9 +305,29 @@ class StabilityLifecycleTests(unittest.TestCase):
         asyncio.run(self.integration.async_setup_entry(hass, entry))
 
         self.assertEqual(hass.http.calls, 1)
+        self.assertEqual(len(frontend._registered), 1)
+        _, panel_kwargs = frontend._registered[0]
+        self.assertEqual(
+            panel_kwargs["config"]["_panel_custom"]["module_url"],
+            self.integration.PANEL_MODULE_URL,
+        )
         self.assertIn("storage", entry.runtime_data)
         self.assertIn("coordinator", entry.runtime_data)
 
+    def test_panel_script_is_loaded_as_a_versioned_module(self):
+        panel_script = (PLANTRUN_DIR / "www" / "plantrun-panel.js").read_text(encoding="utf-8")
+        manifest_version = json.loads((PLANTRUN_DIR / "manifest.json").read_text(encoding="utf-8"))[
+            "version"
+        ]
+
+        self.assertIn('import { LitElement, html, css }', panel_script)
+        self.assertEqual(
+            self.integration.PANEL_MODULE_URL,
+            f"/plantrun_frontend/plantrun-panel.js?v={manifest_version}",
+        )
+        init_source = (PLANTRUN_DIR / "__init__.py").read_text(encoding="utf-8")
+        self.assertIn('"module_url": PANEL_MODULE_URL', init_source)
+        self.assertNotIn('"js_url"', init_source)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Root cause
PlantRun sidebar panel script (`plantrun-panel.js`) is an ES module, but integration registered panel via `_panel_custom.js_url` (classic script loader). On latest HA this causes:

`SyntaxError: Cannot use import statement outside a module`

which leads to blank sidebar screen.

## Why previous fix failed
The prior approach changed frontend script behavior but did not switch the loader contract on `main` to module loading semantics, and did not enforce versioned cache-busting at registration.

## Fix summary
- Switch panel registration from `js_url` to `module_url`
- Use versioned module URL derived from `manifest.json`:
  - `/plantrun_frontend/plantrun-panel.js?v=<version>`
- Add regression tests asserting module_url registration and versioned path.

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- Result: `Ran 22 tests ... OK`

## Manual verification (HA latest)
1. Update via HACS to this PR build
2. Restart HA
3. Hard refresh browser (or open private window)
4. Open PlantRun sidebar
5. Confirm panel loads and no `import statement outside a module` error
6. (Optional) Verify network request includes `plantrun-panel.js?v=<manifest_version>`

## Scope
Hotfix only for sidebar blank screen/import-module crash.
