### PR TITLE
fix: auto-clean obsolete legacy singleton sensors on setup

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     ACTIVE_RUN_STRATEGIES,
@@ -49,6 +50,24 @@ _MANIFEST_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_te
 ]
 PANEL_MODULE_URL = f"/plantrun_frontend/plantrun-panel.js?v={_MANIFEST_VERSION}"
 UPLOADS_SUBDIR = "plantrun_uploads"
+_OBSOLETE_LEGACY_ENTITY_IDS = {
+    "sensor.plantrun_active_cultivar",
+    "sensor.plantrun_active_phase",
+    "sensor.plantrun_active_run",
+    "sensor.plantrun_active_run_count",
+    "sensor.plantrun_last_event",
+    "sensor.plantrun_active_cultivar_breeder",
+    "sensor.plantrun_active_cultivar_flower_window",
+}
+_OBSOLETE_LEGACY_UNIQUE_IDS = {
+    "plantrun_active_cultivar_name",
+    "plantrun_active_phase",
+    "plantrun_active_run",
+    "plantrun_active_run_count",
+    "plantrun_last_event",
+    "plantrun_active_cultivar_breeder",
+    "plantrun_active_cultivar_flower_window",
+}
 
 
 def _write_uploaded_image(output_dir: Path, output_name: str, raw: bytes) -> None:
@@ -66,6 +85,26 @@ def _storage_for_hass(hass: HomeAssistant) -> PlantRunStorage | None:
             if isinstance(storage, PlantRunStorage):
                 return storage
     return None
+
+
+def _is_obsolete_legacy_entity(entity_entry: Any) -> bool:
+    """Return True when an entity registry entry matches a known retired singleton."""
+    return (
+        getattr(entity_entry, "entity_id", None) in _OBSOLETE_LEGACY_ENTITY_IDS
+        or getattr(entity_entry, "unique_id", None) in _OBSOLETE_LEGACY_UNIQUE_IDS
+    )
+
+
+def _async_remove_obsolete_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -> int:
+    """Remove retired singleton sensor registry entries for this config entry."""
+    registry = er.async_get(hass)
+    removed = 0
+    for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not _is_obsolete_legacy_entity(entity_entry):
+            continue
+        registry.async_remove(entity_entry.entity_id)
+        removed += 1
+    return removed
 
 
 @websocket_api.websocket_command({"type": "plantrun/get_runs"})
@@ -168,6 +207,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
     hass.data[DOMAIN][entry.entry_id] = runtime_data
     entry.runtime_data = runtime_data
+
+    removed_legacy_entities = _async_remove_obsolete_legacy_entities(hass, entry)
+    if removed_legacy_entities:
+        _LOGGER.info(
+            "Removed %s obsolete legacy PlantRun sensor registry entr%s during setup.",
+            removed_legacy_entities,
+            "y" if removed_legacy_entities == 1 else "ies",
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/tests/test_stability_lifecycle.py
+++ b/tests/test_stability_lifecycle.py
@@ -162,6 +162,7 @@ def _install_homeassistant_stubs() -> None:
 
     helpers_mod = types.ModuleType("homeassistant.helpers")
     selector_mod = types.ModuleType("homeassistant.helpers.selector")
+    entity_registry_mod = types.ModuleType("homeassistant.helpers.entity_registry")
 
     class DateSelector:
         pass
@@ -177,8 +178,19 @@ def _install_homeassistant_stubs() -> None:
     selector_mod.DateSelector = DateSelector
     selector_mod.EntitySelectorConfig = EntitySelectorConfig
     selector_mod.EntitySelector = EntitySelector
+    def async_get(hass):
+        return hass.entity_registry
+
+    def async_entries_for_config_entry(registry, entry_id):
+        return [entry for entry in registry.entries.values() if entry.config_entry_id == entry_id]
+
+    helpers_mod.__path__ = []
+    helpers_mod.entity_registry = entity_registry_mod
     sys.modules["homeassistant.helpers"] = helpers_mod
     sys.modules["homeassistant.helpers.selector"] = selector_mod
+    entity_registry_mod.async_get = async_get
+    entity_registry_mod.async_entries_for_config_entry = async_entries_for_config_entry
+    sys.modules["homeassistant.helpers.entity_registry"] = entity_registry_mod
 
     aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
     aiohttp_client._session = object()
@@ -289,6 +301,24 @@ class FakeConfig:
         return str(self._root.joinpath(*parts))
 
 
+class FakeEntityRegistryEntry:
+    def __init__(self, entity_id: str, unique_id: str, config_entry_id: str):
+        self.entity_id = entity_id
+        self.unique_id = unique_id
+        self.config_entry_id = config_entry_id
+
+
+class FakeEntityRegistry:
+    def __init__(self, entries=None):
+        self.entries = {entry.entity_id: entry for entry in (entries or [])}
+        self.removed = []
+
+    def async_remove(self, entity_id: str) -> None:
+        if entity_id in self.entries:
+            self.removed.append(entity_id)
+            self.entries.pop(entity_id, None)
+
+
 class StabilityLifecycleTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -367,6 +397,7 @@ class StabilityLifecycleTests(unittest.TestCase):
             services=services,
             config_entries=FakeConfigEntries(),
             async_add_executor_job=async_add_executor_job,
+            entity_registry=FakeEntityRegistry(),
         )
         hass._executor_calls = executor_calls
         return hass
@@ -399,6 +430,76 @@ class StabilityLifecycleTests(unittest.TestCase):
         )
         self.assertIn("storage", entry.runtime_data)
         self.assertIn("coordinator", entry.runtime_data)
+
+    def test_setup_entry_removes_only_known_legacy_singleton_entities(self):
+        hass = self._build_hass()
+        entry = sys.modules["homeassistant.config_entries"].ConfigEntry("entry-cleanup")
+        hass.entity_registry = FakeEntityRegistry(
+            [
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_active_cultivar",
+                    "plantrun_active_cultivar_name",
+                    entry.entry_id,
+                ),
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_active_phase",
+                    "plantrun_active_phase",
+                    entry.entry_id,
+                ),
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_total_plant_runs",
+                    "plantrun_total_runs",
+                    entry.entry_id,
+                ),
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_active_phase_other_entry",
+                    "plantrun_active_phase",
+                    "other-entry",
+                ),
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_active_phase_run123",
+                    "plantrun_active_phase_run123",
+                    entry.entry_id,
+                ),
+            ]
+        )
+
+        asyncio.run(self.integration.async_setup_entry(hass, entry))
+
+        self.assertEqual(
+            hass.entity_registry.removed,
+            [
+                "sensor.plantrun_active_cultivar",
+                "sensor.plantrun_active_phase",
+            ],
+        )
+        self.assertIn("sensor.plantrun_total_plant_runs", hass.entity_registry.entries)
+        self.assertIn("sensor.plantrun_active_phase_other_entry", hass.entity_registry.entries)
+        self.assertIn("sensor.plantrun_active_phase_run123", hass.entity_registry.entries)
+
+    def test_setup_entry_cleanup_is_idempotent(self):
+        hass = self._build_hass()
+        entry = sys.modules["homeassistant.config_entries"].ConfigEntry("entry-cleanup")
+        hass.entity_registry = FakeEntityRegistry(
+            [
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_last_event",
+                    "plantrun_last_event",
+                    entry.entry_id,
+                ),
+                FakeEntityRegistryEntry(
+                    "sensor.plantrun_total_plant_runs",
+                    "plantrun_total_runs",
+                    entry.entry_id,
+                ),
+            ]
+        )
+
+        asyncio.run(self.integration.async_setup_entry(hass, entry))
+        asyncio.run(self.integration.async_setup_entry(hass, entry))
+
+        self.assertEqual(hass.entity_registry.removed, ["sensor.plantrun_last_event"])
+        self.assertIn("sensor.plantrun_total_plant_runs", hass.entity_registry.entries)
 
     def test_panel_script_is_loaded_as_a_versioned_module(self):
         panel_script = (PLANTRUN_DIR / "www" / "plantrun-panel.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Clean up obsolete legacy singleton PlantRun sensors left behind from older integration versions.

## Why
Users upgrading from old versions still see stale singleton entities in HA (e.g. `sensor.plantrun_active_run`, `sensor.plantrun_last_event`) even though current architecture uses per-run entities.

## Changes
- Add setup-time entity-registry cleanup for known obsolete legacy singleton IDs/unique_ids.
- Cleanup is scoped to the current config entry and only exact curated legacy matches.
- Idempotent behavior (safe across repeated setup/reloads).
- Keep current valid entities untouched (including per-run entities and total-runs sensor).

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- Result: `Ran 31 tests ... OK`
- Added lifecycle tests for:
  - removing only known legacy singleton entities
  - idempotent cleanup behavior

## User impact
After update/reload, stale legacy sensors are removed automatically from registry; manual cleanup should no longer be required for known legacy IDs.
