### PR TITLE
fix(ui): replace unsupported soil moisture glyph

### DIFF
--- a/custom_components/plantrun/www/plantrun-panel.js
+++ b/custom_components/plantrun/www/plantrun-panel.js
@@ -915,7 +915,7 @@ class PlantRunDashboardPanel extends LitElement {
     if (key.includes("temp")) return "🌡";
     if (key.includes("humid")) return "💧";
     if (key.includes("light")) return "☀️";
-    if (key.includes("soil") || key.includes("moist")) return "🪴";
+    if (key.includes("soil") || key.includes("moist")) return "💧";
     if (key.includes("energy") || key.includes("power")) return "⚡";
     return "●";
   }


### PR DESCRIPTION
## Summary\n- replace the soil/moisture metric glyph in the run card icon mapper\n- switch from unsupported emoji that rendered as a square on some platforms to a broadly supported droplet glyph\n- keep change minimal (single-line UI mapping update)\n\n## Validation\n- python3 -m unittest discover -s tests -p 'test_*.py'\n\nFixes #33