### PR TITLE
test: harden dashboard panel UI interaction regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Work is being delivered in mergeable slices to keep changes safe and testable.
 
 - Quick pre-PR gate: `./scripts/quick_gate.sh`
 - Direct test command: `python3 -m unittest discover -s tests -q`
+- Dashboard interaction regression suite: `python3 -m unittest tests.test_dashboard_panel_interactions -q`
 - Keep changes scoped and production-runnable per PR
 - Prefer backward-compatible UX/data changes
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package marker.

--- a/tests/dashboard_js_test_utils.py
+++ b/tests/dashboard_js_test_utils.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PANEL_JS = ROOT / "custom_components" / "plantrun" / "www" / "plantrun-panel.js"
+
+
+def load_panel_source() -> str:
+    return PANEL_JS.read_text(encoding="utf-8")
+
+
+def assert_has_snippets(testcase, source: str, snippets: list[str]) -> None:
+    for snippet in snippets:
+        testcase.assertIn(snippet, source)

--- a/tests/test_dashboard_panel_interactions.py
+++ b/tests/test_dashboard_panel_interactions.py
@@ -1,0 +1,49 @@
+import unittest
+
+from tests.dashboard_js_test_utils import assert_has_snippets, load_panel_source
+
+
+class DashboardPanelInteractionRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.source = load_panel_source()
+
+    def test_expansion_state_is_isolated_per_run_id(self):
+        assert_has_snippets(
+            self,
+            self.source,
+            [
+                "const isExpanded = !!this._expandedRuns[runId];",
+                "this._expandedRuns = { ...this._expandedRuns, [runId]: !isExpanded };",
+                "this._expandedRuns = Object.fromEntries(Object.entries(this._expandedRuns).filter(([runId]) => validIds.has(runId)));",
+            ],
+        )
+
+    def test_short_tap_and_long_press_are_single_fire_paths(self):
+        assert_has_snippets(
+            self,
+            self.source,
+            [
+                "state.longPressTriggered = true",
+                "this._openEntity(entityId)",
+                "const wasLongPress = !!state.longPressTriggered;",
+                "if (!wasLongPress)",
+                "this._openRunHistory(runId, entityId);",
+                "delete next[key];",
+            ],
+        )
+
+    def test_rapid_interactions_clear_prior_timer_and_block_click_duplicates(self):
+        assert_has_snippets(
+            self,
+            self.source,
+            [
+                "if (current?.timer)",
+                "window.clearTimeout(current.timer);",
+                "@click=${(e) => e.preventDefault()}",
+                "_sensorPressCancel",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add targeted regression tests for dashboard panel interaction behavior\n- cover expansion state isolation per run id\n- cover short-tap vs long-press single-fire contract and rapid interaction guardrails\n- add small JS test helper utility for stable source-contract assertions\n- document direct command for this suite in README\n\n## Test\n- python3 -m unittest tests.test_dashboard_panel_interactions -q\n- python3 -m unittest discover -s tests -q