### PR TITLE
fix(ui): finalize #78 dashboard UX alignment

### DIFF
--- a/custom_components/plantrun/www/plantrun-panel.js
+++ b/custom_components/plantrun/www/plantrun-panel.js
@@ -383,6 +383,15 @@ class PlantRunDashboardPanel extends LitElement {
         height: 100%;
         background: linear-gradient(90deg, var(--g-mid), var(--g-bright));
       }
+      .range-fill.ok {
+        background: linear-gradient(90deg, var(--g-mid), var(--g-bright));
+      }
+      .range-fill.warn {
+        background: linear-gradient(90deg, #8b6b2b, var(--amber));
+      }
+      .range-fill.high {
+        background: linear-gradient(90deg, #6b2a2a, var(--rose));
+      }
       .phase-title {
         margin-top: 12px;
         margin-bottom: 6px;
@@ -440,6 +449,31 @@ class PlantRunDashboardPanel extends LitElement {
         margin-top: 6px;
         font-size: 9px;
         color: var(--t3);
+      }
+      .range-status {
+        margin-top: 4px;
+        font-size: 9px;
+        color: var(--t2);
+      }
+      .mini-phase-track {
+        display: flex;
+        gap: 6px;
+        margin-top: 8px;
+      }
+      .mini-phase-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: var(--bg-elevated);
+      }
+      .mini-phase-dot.done {
+        border-color: var(--g-mid);
+        background: var(--g-mid);
+      }
+      .mini-phase-dot.current {
+        border-color: var(--g-bright);
+        background: var(--g-bright);
       }
       .run-energy {
         margin-top: 10px;
@@ -1004,6 +1038,14 @@ class PlantRunDashboardPanel extends LitElement {
                     )
                   : html`<span class="chip">No live sensors</span>`}
                 ${unavailableCount ? html`<span class="chip">${unavailableCount} unavailable</span>` : null}
+              </div>
+              <div class="mini-phase-track" data-contract="compact-mini-phase-track" aria-hidden="true">
+                ${PHASES.map((phase) => {
+                  const idx = PHASES.indexOf(phase);
+                  const cur = PHASES.findIndex((x) => x.toLowerCase() === String(currentPhase).toLowerCase());
+                  const klass = idx < cur ? "done" : idx === cur ? "current" : "";
+                  return html`<span class="mini-phase-dot ${klass}" title=${phase}></span>`;
+                })}
               </div>`}
 
           ${expanded
@@ -1505,6 +1547,13 @@ class PlantRunDashboardPanel extends LitElement {
     this._highlightedCultivarSuggestion = -1;
   }
 
+  _clearCultivarSuggestionsSoon() {
+    window.setTimeout(() => {
+      this._cultivarSuggestions = [];
+      this._highlightedCultivarSuggestion = -1;
+    }, 120);
+  }
+
   _openNewRunSetup = () => {
     this._resetSetupForm();
     this._setupOpen = true;
@@ -1688,11 +1737,16 @@ class PlantRunDashboardPanel extends LitElement {
     const span = max - min;
     const normalized = ((numeric - min) / span) * 100;
     const width = Math.max(0, Math.min(100, normalized));
+    const status = numeric < min ? "below" : numeric > max ? "above" : "in_range";
+    const statusClass = status === "below" ? "warn" : status === "above" ? "high" : "ok";
+    const statusLabel = status === "below" ? "Below target" : status === "above" ? "Above target" : "In range";
+
     return html`
       <div class="range-track" aria-hidden="true">
-        <div class="range-fill" style=${`width:${width}%`}></div>
+        <div class="range-fill ${statusClass}" style=${`width:${width}%`}></div>
       </div>
       <div class="range-copy">Target range ${min}-${max}${sensor.unit ? ` ${sensor.unit}` : ""}</div>
+      <div class="range-status">${statusLabel}</div>
     `;
   }
 

--- a/tests/test_dashboard_js_contracts.py
+++ b/tests/test_dashboard_js_contracts.py
@@ -41,6 +41,19 @@ class DashboardJsContractsTests(unittest.TestCase):
         self.assertIn("Estimated run duration (days)", source)
         self.assertIn("Explicit estimate used for planning context", source)
 
+    def test_panel_sensor_range_bar_exposes_status_classes_and_copy(self):
+        source = PANEL_JS.read_text(encoding="utf-8")
+        self.assertIn('const status = numeric < min ? "below" : numeric > max ? "above" : "in_range";', source)
+        self.assertIn('const statusClass = status === "below" ? "warn" : status === "above" ? "high" : "ok";', source)
+        self.assertIn('class="range-fill ${statusClass}"', source)
+        self.assertIn('"Below target"', source)
+        self.assertIn('"In range"', source)
+        self.assertIn('"Above target"', source)
+
+    def test_panel_compact_card_includes_mini_phase_track_marker(self):
+        source = PANEL_JS.read_text(encoding="utf-8")
+        self.assertIn('data-contract="compact-mini-phase-track"', source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_panel_autocomplete.py
+++ b/tests/test_panel_autocomplete.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -15,6 +16,7 @@ class PanelAutocompleteTest(unittest.TestCase):
         self.assertIn('event.key === "Enter" || event.key === "Tab"', source)
         self.assertIn('@mousedown=${(e) => e.preventDefault()}', source)
         self.assertIn("_clearCultivarSuggestionsSoon", source)
+        self.assertRegex(source, r"_clearCultivarSuggestionsSoon\(\)\s*\{")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Finalize remaining dashboard UX alignment items for issue #78 with minimal, low-risk panel updates.

## Changes
- Added sensor range health status computation in `plantrun-panel.js` (`below` / `in_range` / `above`).
- Applied explicit status classes on sensor range fill (`ok` / `warn` / `high`) and added tiny status copy (`Below target` / `In range` / `Above target`).
- Added compact-card mini phase track (non-interactive) for quick scan parity, with contract marker `data-contract="compact-mini-phase-track"`.
- Added missing `_clearCultivarSuggestionsSoon()` method referenced by cultivar input `@blur`.
- Updated dashboard JS contract tests to assert range status tokens/text and compact mini phase-track marker.
- Strengthened autocomplete test to assert `_clearCultivarSuggestionsSoon()` method definition via regex.

## Testing
- `python3 -m unittest discover -s tests -q` (passes)

Fixes #78
