### PR TITLE
fix: resolve PlantRun panel click delegation

### DIFF
--- a/custom_components/plantrun/www/plantrun-panel.js
+++ b/custom_components/plantrun/www/plantrun-panel.js
@@ -1351,7 +1351,7 @@
               <button
                 class="cultivar-option ${this._cultivarIndex === index ? "active" : ""}"
                 data-cultivar-index="${index}"
-                data-cultivar-name="${SHARED.escapeHtml(item.name || "") }"
+                data-cultivar-name="${SHARED.escapeHtml(item.name || "")}"
                 type="button"
               >
                 <strong>${SHARED.escapeHtml(item.name || "Unknown")}</strong>
@@ -1851,9 +1851,26 @@
       }, 130);
     }
 
+    _findDelegatedActionTarget(event) {
+      const path = typeof event.composedPath === "function" ? event.composedPath() : [event.target];
+      for (const node of path) {
+        if (!(node instanceof Element) || !this.shadowRoot.contains(node)) {
+          continue;
+        }
+        if (node.matches?.(DELEGATED_ACTION_SELECTOR)) {
+          return node;
+        }
+        const closest = node.closest?.(DELEGATED_ACTION_SELECTOR);
+        if (closest && this.shadowRoot.contains(closest)) {
+          return closest;
+        }
+      }
+      return null;
+    }
+
     _handleDelegatedClick(event) {
-      const target = event.target.closest(DELEGATED_ACTION_SELECTOR);
-      if (!target || !this.shadowRoot.contains(target)) {
+      const target = this._findDelegatedActionTarget(event);
+      if (!target) {
         return;
       }
       if (target.dataset.page) {

--- a/tests/test_dashboard_panel_interactions.py
+++ b/tests/test_dashboard_panel_interactions.py
@@ -44,14 +44,16 @@ class DashboardPanelInteractionRegressionTests(unittest.TestCase):
             ],
         )
 
-    def test_delegated_clicks_are_scoped_to_shadow_root_actions(self):
+    def test_delegated_clicks_walk_the_composed_path_inside_shadow_root(self):
         assert_has_snippets(
             self,
             self.source,
             [
                 "const DELEGATED_ACTION_SELECTOR = [",
-                "event.target.closest(DELEGATED_ACTION_SELECTOR)",
-                "if (!target || !this.shadowRoot.contains(target))",
+                "const path = typeof event.composedPath === \"function\" ? event.composedPath() : [event.target];",
+                "if (!(node instanceof Element) || !this.shadowRoot.contains(node))",
+                "if (node.matches?.(DELEGATED_ACTION_SELECTOR))",
+                "const closest = node.closest?.(DELEGATED_ACTION_SELECTOR);",
             ],
         )
 


### PR DESCRIPTION
## Summary
- fix the remaining PlantRun panel interaction bug where clicks could still fail inside the shadow DOM
- resolve delegated action lookup by walking the composed event path instead of relying on `event.target.closest(...)`
- keep the earlier UI hotfixes intact

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'` ✅
- `node --check custom_components/plantrun/www/plantrun-panel.js` ✅
- `node --check custom_components/plantrun/www/plantrun-card.js` ✅
- `node --check custom_components/plantrun/www/plantrun-card-editor.js` ✅
