### PR TITLE
fix: bust PlantRun panel script cache

### DIFF
--- a/custom_components/plantrun/__init__.py
+++ b/custom_components/plantrun/__init__.py
@@ -74,7 +74,10 @@ PANEL_ICON = "mdi:sprout"
 _MANIFEST_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_text(encoding="utf-8"))[
     "version"
 ]
-PANEL_MODULE_URL = f"/plantrun_frontend/plantrun-panel.js?v={_MANIFEST_VERSION}"
+_PANEL_SCRIPT_PATH = Path(__file__).parent / "www" / "plantrun-panel.js"
+_PANEL_SCRIPT_CACHE_KEY = f"{_MANIFEST_VERSION}-{int(_PANEL_SCRIPT_PATH.stat().st_mtime)}"
+PANEL_MODULE_URL = f"/plantrun_frontend/plantrun-panel.js?v={_PANEL_SCRIPT_CACHE_KEY}"
+PANEL_JS_URL = PANEL_MODULE_URL
 UPLOADS_SUBDIR = "plantrun_uploads"
 _OBSOLETE_LEGACY_ENTITY_IDS = {
     "sensor.plantrun_active_cultivar",
@@ -271,7 +274,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "trust_external": False,
                     # Keep both for cross-version HA compatibility.
                     "module_url": PANEL_MODULE_URL,
-                    "js_url": "/plantrun_frontend/plantrun-panel.js",
+                    "js_url": PANEL_JS_URL,
                 }
             },
             require_admin=False,

--- a/tests/test_stability_lifecycle.py
+++ b/tests/test_stability_lifecycle.py
@@ -445,6 +445,10 @@ class StabilityLifecycleTests(unittest.TestCase):
             panel_kwargs["config"]["_panel_custom"]["module_url"],
             self.integration.PANEL_MODULE_URL,
         )
+        self.assertEqual(
+            panel_kwargs["config"]["_panel_custom"]["js_url"],
+            self.integration.PANEL_JS_URL,
+        )
         self.assertIn("storage", entry.runtime_data)
         self.assertIn("coordinator", entry.runtime_data)
 
@@ -523,13 +527,13 @@ class StabilityLifecycleTests(unittest.TestCase):
         manifest_version = json.loads((PLANTRUN_DIR / "manifest.json").read_text(encoding="utf-8"))[
             "version"
         ]
+        panel_mtime = int((PLANTRUN_DIR / "www" / "plantrun-panel.js").stat().st_mtime)
+        expected_url = f"/plantrun_frontend/plantrun-panel.js?v={manifest_version}-{panel_mtime}"
 
         self.assertNotIn('import {', panel_script)
         self.assertIn('customElements.get("ha-panel-lovelace")', panel_script)
-        self.assertEqual(
-            self.integration.PANEL_MODULE_URL,
-            f"/plantrun_frontend/plantrun-panel.js?v={manifest_version}",
-        )
+        self.assertEqual(self.integration.PANEL_MODULE_URL, expected_url)
+        self.assertEqual(self.integration.PANEL_JS_URL, expected_url)
 
     def test_options_flow_uses_shared_session_for_seedfinder_lookup(self):
         ConfigEntry = sys.modules["homeassistant.config_entries"].ConfigEntry


### PR DESCRIPTION
## Summary
- add a real cache-busting key for the dashboard panel script using integration version + panel file mtime
- apply the same versioned URL to both `module_url` and legacy `js_url`
- cover the panel registration contract in stability tests

## Why
Home Assistant could keep serving an older `plantrun-panel.js` even after hotfixes because:
- the integration manifest version stayed `0.1.0`
- `js_url` had no cache buster at all

That makes the earlier click fixes easy to miss in live HA testing even when `main` changed.

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'` ✅
- `node --check custom_components/plantrun/www/plantrun-panel.js` ✅
- `node --check custom_components/plantrun/www/plantrun-card.js` ✅
- `node --check custom_components/plantrun/www/plantrun-card-editor.js` ✅
